### PR TITLE
Refactor presence validator

### DIFF
--- a/lib/poro_validator/validators/presence_validator.rb
+++ b/lib/poro_validator/validators/presence_validator.rb
@@ -1,11 +1,20 @@
 module PoroValidator
   module Validators
     class PresenceValidator < BaseClass
-      def validate(attribute, value, options)
-        message = options.fetch(:message, :presence)
-        v = value.is_a?(String) ? value.gsub(/\s+/, '') : value
+      BLANK_STRING_MATCHER = /\A[[:space:]]*\z/.freeze
 
-        if v.nil? || v.respond_to?(:empty?) && v.empty?
+      def validate(attribute, value, options)
+        allow_blank = options.fetch(:allow_blank, false)
+        message = options.fetch(:message, :presence)
+
+        if value.is_a?(::String)
+          if value.gsub(/\s+/, '').match(BLANK_STRING_MATCHER)
+            errors.add(attribute, message) unless allow_blank
+            return
+          end
+        end
+
+        if value.nil? || (value.respond_to?(:empty?) && value.empty?)
           errors.add(attribute, message)
         end
       end

--- a/spec/lib/poro_validator/validators/presence_validator_spec.rb
+++ b/spec/lib/poro_validator/validators/presence_validator_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe PoroValidator::Validators::PresenceValidator do
 
         validates :first_name, presence: true
         validates :last_name, presence: true, if: proc { true }
+        validates :nickname, presence: { allow_blank: true }
         validates :dob, presence: true, if: proc { false }
       end.new
     end
@@ -19,6 +20,7 @@ RSpec.describe PoroValidator::Validators::PresenceValidator do
         OpenStruct.new(
           first_name: nil,
           last_name: nil,
+          nickname: nil,
           dob: nil
         )
       end
@@ -26,7 +28,8 @@ RSpec.describe PoroValidator::Validators::PresenceValidator do
       let(:expected_errors) do
         {
           "first_name" => ["is not present"],
-          "last_name" => ["is not present"],
+          "last_name"  => ["is not present"],
+          "nickname"   => ["is not present"]
         }
       end
 
@@ -40,6 +43,7 @@ RSpec.describe PoroValidator::Validators::PresenceValidator do
         OpenStruct.new(
           first_name: "manbearpig",
           last_name: "gore",
+          nickname: "",
           dob: "01/01/1977"
         )
       end


### PR DESCRIPTION
:dancer: :bee:

Refactored presence validator.
Added additional options for presence validator by allowing an option accessor ```allow_blank```.