### PR TITLE
Allow hashes for `with` validator

### DIFF
--- a/lib/poro_validator/validators/with_validator.rb
+++ b/lib/poro_validator/validators/with_validator.rb
@@ -6,7 +6,11 @@ module PoroValidator
         case validator_class
         when Class
           klass = validator_class.new
-          klass.valid?(context.entity.public_send(attribute))
+          if context.entity.is_a?(::Hash)
+            klass.valid?(context.entity[attribute] || {})
+          else
+            klass.valid?(context.entity.public_send(attribute))
+          end
           klass.errors.public_send(:store).data.each do |k,v|
             errors.add([attribute, k.to_sym], v.pop)
           end

--- a/lib/poro_validator/version.rb
+++ b/lib/poro_validator/version.rb
@@ -1,3 +1,3 @@
 module PoroValidator
-  VERSION = "0.1.1"
+  VERSION = "0.1.2"
 end

--- a/spec/lib/poro_validator/validators/with_validator_spec.rb
+++ b/spec/lib/poro_validator/validators/with_validator_spec.rb
@@ -49,6 +49,28 @@ RSpec.describe PoroValidator::Validators::WithValidator do
       end
     end
 
+    context "entity is a hash object" do
+      expect_validator_to_be_invalid do
+        let(:entity) do
+          {}
+        end
+
+        let(:expected_errors) do
+          {
+            "first_name" => ["is not present"],
+            "last_name" => ["is not present"],
+            "{:address=>:line1}" => ["is not present"],
+            "{:address=>:line2}" => ["is not present"]
+          }
+        end
+
+        skip_attr_unmet_condition do
+          let(:attr) { :dob }
+        end
+      end
+
+    end
+
     expect_validator_to_be_valid do
       let(:entity) do
         OpenStruct.new(

--- a/spec/support/spec_helpers/validator_test_macros.rb
+++ b/spec/support/spec_helpers/validator_test_macros.rb
@@ -82,7 +82,9 @@ module SpecHelpers
           let(:attr) { raise "You must override the let(:attr)!" }
 
           it "does not validate the attribute" do
-            expect(entity).to respond_to(attr)
+            unless entity.is_a?(::Hash)
+              expect(entity).to respond_to(attr)
+            end
             validator.valid?(entity)
             expect(validator.errors.on(attr)).to be_nil,
               expected_message = [


### PR DESCRIPTION
Add support for hash objects when using the with validator.

This was feature support was missed when adding support for validating
hash objects.