### PR TITLE
Fix initialization of error store

### DIFF
--- a/lib/poro_validator/errors.rb
+++ b/lib/poro_validator/errors.rb
@@ -40,7 +40,7 @@ module PoroValidator
     end
 
     def clear_errors
-      store.reset
+      self.store.reset
     end
 
     alias_method :[], :on

--- a/lib/poro_validator/validator.rb
+++ b/lib/poro_validator/validator.rb
@@ -63,7 +63,7 @@ module PoroValidator
     end
 
     def errors
-      @errors ||= ::PoroValidator::Errors.new
+      @errors
     end
 
     def valid?(entity)
@@ -78,8 +78,8 @@ module PoroValidator
     private
 
     def validate_entity(entity)
-      errors.clear_errors
-      context = Context.new(entity, self, errors)
+      @errors = PoroValidator::Errors.new
+      context = Context.new(entity, self, @errors)
       self.class.validations.run_validations(context)
     end
   end

--- a/lib/poro_validator/version.rb
+++ b/lib/poro_validator/version.rb
@@ -1,3 +1,3 @@
 module PoroValidator
-  VERSION = "0.2.2"
+  VERSION = "0.2.3"
 end

--- a/spec/features/reuse_validator_spec.rb
+++ b/spec/features/reuse_validator_spec.rb
@@ -1,0 +1,53 @@
+require 'spec_helper'
+
+RSpec.describe "Allows initialized validations to be reused", type: :feature do
+  it "allows reuse of the validation class" do
+    widget = Struct.new(:name, :size)
+    validator = Class.new do
+      include PoroValidator.validator
+
+      validates :name, inclusion: 'c'..'d'
+      validates :size, numeric: 2..3
+    end
+
+    widgets = ('a'..'d').map.with_index(1) do |n, s|
+      widget.new(n, s)
+    end
+
+    wv = validator.new
+    errors = widgets.map { |w| wv.valid?(w); wv.errors }
+    expect(
+      errors.map(&:empty?)
+    ).to eq([false, false, true, false])
+  end
+
+  # Story:
+  # @pid
+  # Widget = Struct.new(:name, :size)
+  #
+  # class WV
+  #   include PoroValidator.validator
+  #   validates :name, inclusion: 'c'..'d'
+  #   validates :size, numeric: 2..3
+  # end
+  #
+  # widgets = ('a'..'d').map.with_index(1) do |n, s|
+  #   Widget.new(n, s)
+  # end
+  #
+  # # actual validity:
+  # aaa = widgets.map { |w| WV.new.valid?(w) }
+  # puts aaa.join(" ")
+  # #=> [false, false, true, false]
+  #
+  # # but when reusing a validator instance:
+  # wv = WV.new
+  # errors = widgets.map { |w| wv.valid?(w); wv.errors }
+  # puts (errors.map(&:empty?)).join(" ")
+  # #=> [false, false, false, false]
+  #
+  # require 'pry'; binding.pry
+  # # because:
+  # widgets.map { |w| wv.valid?(w); wv.errors.object_id }.uniq.size
+  # #=> 1
+end


### PR DESCRIPTION
:dancer: :bee:

When the validator is reused, the error store class does not get cleared properly
because the initialization of the error class was incorrect.
